### PR TITLE
Update nodejs through Debian

### DIFF
--- a/ruby-2-5-redis-postgres/Dockerfile
+++ b/ruby-2-5-redis-postgres/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:2.5-stretch
+FROM ruby:2.5-buster
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
   && wget --no-check-certificate -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add - \
   && apt-get update
 


### PR DESCRIPTION
This moves the base image to Debian Buster so that we get an updated nodejs version.