### PR TITLE
Update databases on ruby 2.6 image

### DIFF
--- a/ruby-2-6-redis-postgres/Dockerfile
+++ b/ruby-2-6-redis-postgres/Dockerfile
@@ -1,10 +1,6 @@
-FROM ruby:2.6-stretch
+FROM ruby:2.6-slim
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
-  && wget --no-check-certificate -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add - \
-  && apt-get update
-
-RUN apt-get -y install sudo postgresql-9.6 redis-server nodejs
+RUN apt -y install postgresql-11 redis-server
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
This uses the latest available version of the databases on the ruby:2.6-slim image.